### PR TITLE
Add CLI entry point for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ And the output would be something like (note it's not deterministic, and sometim
 Answer: (5 * (10 - 4)) - 6 = 24
 ```
 
+## Command Line Interface
+After installing the package you can also run tasks directly from the command line:
+
+```bash
+tot --task game24 --method_generate propose --method_evaluate value \
+    --task_start_index 0 --task_end_index 1
+```
+
+The CLI exposes the same arguments as `run.py`.
+
 ## Paper Experiments
 
 Run experiments via ``sh scripts/{game24, text, crosswords}/{standard_sampling, cot_sampling, bfs}.sh``, except in crosswords we use a DFS algorithm for ToT, which can be run via ``scripts/crosswords/search_crosswords-dfs.ipynb``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,8 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools.packages.find]
 where = ["src"]  # list of folders that contain the packages (["."] by default)
 
+[project.scripts]
+tot = "tot.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/princeton-nlp/tree-of-thought-llm"

--- a/src/tot/__main__.py
+++ b/src/tot/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tot/cli.py
+++ b/src/tot/cli.py
@@ -1,0 +1,78 @@
+import os
+import json
+import argparse
+from .tasks import get_task
+
+
+def run(args: argparse.Namespace) -> None:
+    from .methods.bfs import solve, naive_solve
+    from .models import gpt_usage
+
+    task = get_task(args.task)
+    logs, cnt_avg, cnt_any = [], 0, 0
+    if args.naive_run:
+        file = (
+            f"./logs/{args.task}/{args.backend}_{args.temperature}_naive_{args.prompt_sample}_"
+            f"sample_{args.n_generate_sample}_start{args.task_start_index}_end{args.task_end_index}.json"
+        )
+    else:
+        file = (
+            f"./logs/{args.task}/{args.backend}_{args.temperature}_"
+            f"{args.method_generate}{args.n_generate_sample}_"
+            f"{args.method_evaluate}{args.n_evaluate_sample}_"
+            f"{args.method_select}{args.n_select_sample}_"
+            f"start{args.task_start_index}_end{args.task_end_index}.json"
+        )
+    os.makedirs(os.path.dirname(file), exist_ok=True)
+
+    for i in range(args.task_start_index, args.task_end_index):
+        if args.naive_run:
+            ys, info = naive_solve(args, task, i)
+        else:
+            ys, info = solve(args, task, i)
+
+        infos = [task.test_output(i, y) for y in ys]
+        info.update({"idx": i, "ys": ys, "infos": infos, "usage_so_far": gpt_usage(args.backend)})
+        logs.append(info)
+        with open(file, "w") as f:
+            json.dump(logs, f, indent=4)
+
+        accs = [info["r"] for info in infos]
+        cnt_avg += sum(accs) / len(accs)
+        cnt_any += any(accs)
+        print(i, "sum(accs)", sum(accs), "cnt_avg", cnt_avg, "cnt_any", cnt_any, "\n")
+
+    n = args.task_end_index - args.task_start_index
+    print(cnt_avg / n, cnt_any / n)
+    print("usage_so_far", gpt_usage(args.backend))
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Tree of Thoughts task runner")
+    parser.add_argument("--backend", type=str, choices=["gpt-4", "gpt-3.5-turbo", "gpt-4o"], default="gpt-4")
+    parser.add_argument("--temperature", type=float, default=0.7)
+
+    parser.add_argument("--task", type=str, required=True, choices=list(get_task.__globals__["_TASK_REGISTRY"].keys()))
+    parser.add_argument("--task_start_index", type=int, default=900)
+    parser.add_argument("--task_end_index", type=int, default=1000)
+
+    parser.add_argument("--naive_run", action="store_true")
+    parser.add_argument("--prompt_sample", type=str, choices=["standard", "cot"], help="only used when method_generate = sample, or naive_run")
+
+    parser.add_argument("--method_generate", type=str, choices=["sample", "propose"])
+    parser.add_argument("--method_evaluate", type=str, choices=["value", "vote"])
+    parser.add_argument("--method_select", type=str, choices=["sample", "greedy"], default="greedy")
+    parser.add_argument("--n_generate_sample", type=int, default=1)
+    parser.add_argument("--n_evaluate_sample", type=int, default=1)
+    parser.add_argument("--n_select_sample", type=int, default=1)
+
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> None:
+    args = parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tot/tasks/__init__.py
+++ b/src/tot/tasks/__init__.py
@@ -1,12 +1,41 @@
-def get_task(name):
-    if name == 'game24':
-        from tot.tasks.game24 import Game24Task
-        return Game24Task()
-    elif name == 'text':
-        from tot.tasks.text import TextTask
-        return TextTask()
-    elif name == 'crosswords':
-        from tot.tasks.crosswords import MiniCrosswordsTask
-        return MiniCrosswordsTask()
-    else:
-        raise NotImplementedError
+"""Task registry and helper utilities."""
+
+from importlib import import_module
+from typing import Dict, Type
+
+from .base import Task
+
+
+_TASK_REGISTRY: Dict[str, str] = {
+    "game24": "tot.tasks.game24.Game24Task",
+    "text": "tot.tasks.text.TextTask",
+    "crosswords": "tot.tasks.crosswords.MiniCrosswordsTask",
+}
+
+
+def register_task(name: str, cls: Type[Task]) -> None:
+    """Register a new task class."""
+
+    path = f"{cls.__module__}.{cls.__name__}"
+    _TASK_REGISTRY[name] = path
+
+
+def _load(path: str) -> Type[Task]:
+    module_path, cls_name = path.rsplit(".", 1)
+    module = import_module(module_path)
+    return getattr(module, cls_name)
+
+
+def get_task(name: str) -> Task:
+    """Instantiate a task by ``name``."""
+
+    if name not in _TASK_REGISTRY:
+        raise NotImplementedError(f"Task {name!r} is not implemented")
+    return _load(_TASK_REGISTRY[name])()
+
+
+def available_tasks() -> Dict[str, str]:
+    """Return a mapping of available task names to class paths."""
+
+    return dict(_TASK_REGISTRY)
+


### PR DESCRIPTION
## Summary
- provide a task registry and helper utilities for creation
- add a new `tot` command line interface
- allow `python -m tot` execution
- document CLI usage in README

## Testing
- `python -m compileall -q src/tot`
- `PYTHONPATH=src python -m tot.cli --help | head`

------
https://chatgpt.com/codex/tasks/task_e_68674e29debc832486850151085aef6b